### PR TITLE
Fix #10: submit register_password with the correct value

### DIFF
--- a/html/LoginDialog.html
+++ b/html/LoginDialog.html
@@ -37,8 +37,8 @@
 	</div>
 	
 	<div class="dialog-row">
-	  <input class="is-password" id="register_password" data-i18n-placeholder="Password" data-i18n-tooltip="tooltip-register-password">
-	  <button class="ui-button ui-widget hide-password" name="register_password"></button>
+	  <input class="is-password" id="register_password" data-i18n-placeholder="Password" data-i18n-tooltip="tooltip-register-password" name="register_password">
+	  <button class="ui-button ui-widget hide-password"></button>
 	</div>
 	
 	<div class="dialog-row">


### PR DESCRIPTION
The current UI was incorrectly submitting the `register_password` field's value; that caused the user to be created without a `pass` field (the user password's hash), which would cause subsequent sign in attempts to fail.

This should fix #10.