### PR TITLE
fix: i18n arguments and black tile classing

### DIFF
--- a/js/browser/Ui.js
+++ b/js/browser/Ui.js
@@ -36,8 +36,7 @@ define('browser/Ui', [
 		else if (args instanceof Error) // Error object
 			message = args.toString();
 		else if (args instanceof Array) { // First element i18n code
-			args[0] = $.i18n(args[0]);
-			message = args.join(" ");
+			message = $.i18n.apply($.i18n, args);
 		} else // something else
 			message = args.toString();
 		$('#alertDialog')

--- a/js/game/Square.js
+++ b/js/game/Square.js
@@ -164,6 +164,8 @@ define('game/Square', ['platform'], (Platform) => {
 
 			if (this.tile.isBlank)
 				$div.addClass('blank-letter');
+			else
+				$div.removeClass('blank-letter');
 
 			if (this.tileLocked) {
 				$div.addClass('Locked');
@@ -218,6 +220,7 @@ define('game/Square', ['platform'], (Platform) => {
 			// no tile on the square, valid drop target
 			$div
 			.removeClass("tiled-square")
+			.removeClass('blank-letter')
 			.addClass('empty-square');
 
 			$div.on('click', () => Platform.trigger('SelectSquare', [ this ]))
@@ -234,6 +237,7 @@ define('game/Square', ['platform'], (Platform) => {
 			const text = $.i18n(`square-${this.type}`);
 			$div.addClass('empty-square')
 			.removeClass("tiled-square")
+			.removeClass('blank-letter')
 			.html(`<a>${text}</a>`);
 		}
 	}		


### PR DESCRIPTION
I am not sure what was the original intention, but arguments ($1, $2...) are not correctly filled when error is issued.