### PR TITLE
fix: take back button, remove single quote

### DIFF
--- a/html/CreateGameDialog.html
+++ b/html/CreateGameDialog.html
@@ -41,7 +41,7 @@
 </div>
 
 <div class="dialog-row">
-  <label for="rejectBadPlays" data-i18n="Disallow unknown words'"></label>
+  <label for="rejectBadPlays" data-i18n="Disallow unknown words"></label>
   <input type="checkbox" id="rejectBadPlays" data-i18n-tooltip="tooltip-reject-bad-plays" name="rejectBadPlays"/>
 </div>
 

--- a/js/browser/Ui.js
+++ b/js/browser/Ui.js
@@ -1633,7 +1633,7 @@ define('browser/Ui', [
 				  .text($.i18n('Take back'))
 				  .button()
 				  .on('click', () => this.takeBackMove());
-			addToLog($button, 'turn-control');
+			addToLog(true, $button, 'turn-control');
 		}
 
 		/**


### PR DESCRIPTION
Take back button is not visible due to missing first argument. Shows 'turn-control' string instead.
A single quote is left from copying on 'Disallow unknown words'.