### PR TITLE
Minor fixes

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -3,7 +3,7 @@
 FROM node:12-alpine
 ENV NODE_ENV=production
 WORKDIR /app
-ADD . .
+COPY ["package.json", "package-lock.json*", "./"]
 RUN npm install --production
+COPY . .
 EXPOSE 9093
-CMD [ "npm", "run", "server" ]

--- a/bin/server.js
+++ b/bin/server.js
@@ -144,7 +144,7 @@ requirejs([ "server/Server" ], Server => {
         transport = config.mail.transport;
       
       if (transport)
-        config.mail.transport = NodeMailer.createTransport(
+        config.mail.transport = nodemailer.createTransport(
           transport);
     }
 


### PR DESCRIPTION
Nodemailer is spelled wrong and it makes sense to copy package.json etc. first, do install and files later, so the dependencies are not installed in each rebuild.