### PR TITLE
tweak: make npm "files" rule more restrictive for "games" directory

### DIFF
--- a/package.json
+++ b/package.json
@@ -25,7 +25,7 @@
 		"dist/*.html",
 		"dist/**/*",
 		"editions/*.json",
-		"games/*",
+		"games/README",
 		"html/*.html",
 		"i18n/*.json",
 		"images/*",


### PR DESCRIPTION
this is something that was nagging at me..
I originally made this rule far too permissive