### PR TITLE
fixes missing return when using forEachTiledSquare

### DIFF
--- a/src/game/Surface.js
+++ b/src/game/Surface.js
@@ -149,6 +149,7 @@ class Surface {
     this.forEachTiledSquare(square => {
       removed.push(square.tile);
       square.unplaceTile();
+      return false;
     });
     return removed;
   }


### PR DESCRIPTION
`forEachTiledSquare` expects an boolean return value. In `empty()` this function was used without returning a boolean